### PR TITLE
Make gem compatible with Mongoid 5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,40 +3,36 @@ PATH
   specs:
     mongoid-fixture_set (1.4.1)
       activesupport (~> 4.0)
-      mongoid (~> 4.0)
+      mongoid (>= 4.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.0)
-      activesupport (= 4.2.0)
+    activemodel (4.2.4)
+      activesupport (= 4.2.4)
       builder (~> 3.1)
-    activesupport (4.2.0)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    bson (2.3.0)
+    bson (3.2.4)
     builder (3.2.2)
     coderay (1.1.0)
-    connection_pool (2.1.1)
     docile (1.1.5)
     i18n (0.7.0)
-    json (1.8.2)
+    json (1.8.3)
     method_source (0.8.2)
-    minitest (5.5.1)
-    mongoid (4.0.0)
+    minitest (5.8.1)
+    mongo (2.1.0)
+      bson (~> 3.0)
+    mongoid (5.0.0)
       activemodel (~> 4.0)
-      moped (~> 2.0.0)
+      mongo (~> 2.1)
       origin (~> 2.1)
       tzinfo (>= 0.3.37)
-    moped (2.0.3)
-      bson (~> 2.2)
-      connection_pool (~> 2.0)
-      optionable (~> 0.2.0)
     multi_json (1.10.1)
-    optionable (0.2.0)
     origin (2.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -51,7 +47,7 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
 
@@ -63,3 +59,6 @@ DEPENDENCIES
   pry-nav (~> 0.2.4)
   rake (>= 0.9)
   simplecov
+
+BUNDLED WITH
+   1.10.5

--- a/mongoid-fixture_set.gemspec
+++ b/mongoid-fixture_set.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files       = Dir['{lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files  = Dir['test/**/*']
 
-  s.add_dependency 'mongoid',       '~> 4.0'
+  s.add_dependency 'mongoid',       '>= 4.0'
   s.add_dependency 'activesupport', '~> 4.0'
 end
 


### PR DESCRIPTION
I needed this gem to work in my setup with Mongoid 5.0 and it seems as if just changing the `.gemspec` to support everything up from version 4.0 (including 5.0) works fine.

I can imagine that you don't want to release this as-is, but I just wanted to share that this gem is actually compatible with Mongoid 5.0.
